### PR TITLE
Convert library dropdown row into its own reusable component

### DIFF
--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -997,7 +997,7 @@ sub ItemDataLoaded(msg)
         if m.loadedItems = 0
             m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
             m.emptyText.visible = true
-            m.dropdownOptionGroup@.setFocus("voiceBox")
+            m.dropdownOptionGroup@.setFocus("voiceBox", true)
             m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
         end if
 

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -4,6 +4,7 @@ import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/CollectionType.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/DropdownMenuID.bs"
 import "pkg:/source/enums/ExitDirection.bs"
 import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/ItemType.bs"
@@ -106,17 +107,17 @@ sub onReturnData()
 
     optionType = chainLookup(selectedOptionData, "id")
 
-    if isStringEqual(optionType, tr("Sort Order"))
+    if isStringEqual(optionType, DropdownMenuID.SORTORDER)
         onSortOrderChange(selectedOptionData)
         return
     end if
 
-    if isStringEqual(optionType, tr("Sort By"))
+    if isStringEqual(optionType, DropdownMenuID.SORTBY)
         onSortChange(selectedOptionData)
         return
     end if
 
-    if isStringEqual(optionType, tr("TAB_VIEW"))
+    if isStringEqual(optionType, DropdownMenuID.VIEW)
         onViewChange(selectedOptionData)
         return
     end if

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1150,7 +1150,7 @@ end sub
 sub onItemFocused()
     focusedRow = m.itemGrid.currFocusRow
 
-    if m.itemGrid.isinFocusChain() or m.dropdownOptionsGroup.isinFocusChain()
+    if m.itemGrid.isinFocusChain() or m.dropdownOptionGroup.isinFocusChain()
         if focusedRow = 0
             if m.dropdownOptionGroup.opacity < 1
                 toggleDropdownOptions(true)

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -116,7 +116,7 @@ sub onReturnData()
         return
     end if
 
-    if isStringEqual(optionType, tr("View"))
+    if isStringEqual(optionType, tr("TAB_VIEW"))
         onViewChange(selectedOptionData)
         return
     end if

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -999,8 +999,6 @@ sub ItemDataLoaded(msg)
             m.emptyText.visible = true
             m.dropdownOptionGroup@.setFocus("voiceBox")
             m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = m.voiceBox
         end if
 
         return
@@ -1061,8 +1059,6 @@ sub ItemDataLoaded(msg)
         m.emptyText.visible = true
         m.dropdownOptionGroup@.setFocus("voiceBox")
         m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
-        group = m.global.sceneManager.callFunc("getActiveScene")
-        group.lastFocus = m.voiceBox
     end if
 
     stopLoadingSpinner()

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1745,7 +1745,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 toggleDropdownOptions(true)
             end if
 
-            overhangButton = m.dropdownOptionGroup@.getOverhangingButton(m.itemGrid.numColumns, m.itemGrid.currFocusColumn)
+            activeGrid = m.genreList.isinFocusChain() ? m.genreList : m.itemGrid
+            numColumns = m.genreList.isinFocusChain() ? m.genreList.content.getChild(0).getChildCount() : m.itemGrid.numColumns
+            overhangButton = m.dropdownOptionGroup@.getOverhangingButton(numColumns, activeGrid.currFocusColumn)
+
             m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
 
             if overhangButton.isSubType("VoiceTextEditBox")

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -4,6 +4,7 @@ import "pkg:/source/enums/AnimationControl.bs"
 import "pkg:/source/enums/AnimationState.bs"
 import "pkg:/source/enums/CollectionType.bs"
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ExitDirection.bs"
 import "pkg:/source/enums/ImageLayout.bs"
 import "pkg:/source/enums/ItemType.bs"
 import "pkg:/source/enums/KeyCode.bs"
@@ -23,6 +24,8 @@ sub setupNodes()
     m.top.imageDisplayMode = "scaleToZoom"
     m.top.showItemTitles = "showonhover"
 
+    m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
+
     m.librarySettings = m.top.findNode("librarySettings")
     m.librarySettings.observeFieldScoped("selected", "onLibrarySettingsSelected")
     m.librarySettings.highlightBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
@@ -34,8 +37,6 @@ sub setupNodes()
     m.dropdownOptionsFade = m.top.findNode("dropdownOptionsFade")
     m.options = m.top.findNode("options")
     m.itemGrid = m.top.findNode("itemGrid")
-    m.voiceBox = m.top.findNode("voiceBox")
-    m.voiceBoxBackground = m.top.findNode("voiceBoxBackground")
     m.backdrop = m.top.findNode("backdrop")
     m.newBackdrop = m.top.findNode("backdropTransition")
     m.emptyText = m.top.findNode("emptyText")
@@ -54,8 +55,71 @@ sub setupNodes()
     m.genreList = m.top.findNode("genrelist")
     m.infoGroup = m.top.findNode("infoGroup")
     m.star = m.top.findNode("star")
-    m.dropdownOptions = m.top.findNode("dropdownOptions")
     m.dropdownOptionGroup = m.top.findNode("dropdownOptionGroup")
+    m.dropdownOptionGroup.observeFieldScoped("showOptions", "onShowOptionsChange")
+    m.dropdownOptionGroup.observeFieldScoped("exit", "onExit")
+    m.dropdownOptionGroup.observeFieldScoped("searchTerm", "onSearchTermChanged")
+end sub
+
+sub onShowOptionsChange()
+    m.options.visible = true
+    m.options.findNode("filterMenu").setFocus(true)
+    group = m.global.sceneManager.callFunc("getActiveScene")
+    group.lastFocus = m.options
+end sub
+
+sub onExit()
+    dropdownExitDirection = m.dropdownOptionGroup.exit
+
+    if dropdownExitDirection = ExitDirection.LEFT
+        alphaDisplayed = m.alpha.callFunc("getDisplay")
+
+        if alphaDisplayed
+            m.top.alphaActive = true
+            m.alphaMenu.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.alphaMenu
+        else
+            m.librarySettings.setFocus(true)
+            m.librarySettings.highlighted = true
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.librarySettings
+        end if
+
+        return
+    end if
+
+    if dropdownExitDirection = ExitDirection.DOWN
+        if m.loadedItems = 0 then return
+
+        m.itemGrid.setFocus(m.itemGrid.opacity = 1)
+        m.genreList.setFocus(m.genreList.opacity = 1)
+
+        group = m.global.sceneManager.callFunc("getActiveScene")
+        group.lastFocus = m.itemGrid
+    end if
+end sub
+
+sub onReturnData()
+    selectedOptionData = m.global.sceneManager.returnData
+    if not isValidAndNotEmpty(selectedOptionData) then return
+
+    optionType = chainLookup(selectedOptionData, "id")
+
+    if isStringEqual(optionType, tr("Sort Order"))
+        onSortOrderChange(selectedOptionData)
+        return
+    end if
+
+    if isStringEqual(optionType, tr("Sort By"))
+        onSortChange(selectedOptionData)
+        return
+    end if
+
+    if isStringEqual(optionType, tr("View"))
+        onViewChange(selectedOptionData)
+        return
+    end if
 end sub
 
 sub init()
@@ -90,9 +154,6 @@ sub init()
     m.genreList.observeFieldScoped("itemSelected", "onGenreItemSelected")
     m.genreList.content = m.genreData
 
-    'Voice filter setup
-    m.voiceBox.observeField("text", "onvoiceFilter")
-
     'backdrop
     m.newBackdrop.observeField("loadStatus", "newBGLoaded")
 
@@ -119,53 +180,6 @@ sub init()
     'set inital counts for overhang before content is loaded.
     m.loadItemsTask.observeField("content", "ItemDataLoaded")
     m.loadItemsTask.totalRecordCount = 0
-
-    if not m.global.device.hasVoiceRemote
-        m.voiceBox.backgroundUri = "pkg:/images/transparent.png"
-        m.voiceBox.translation = "[15, 0]"
-        m.voiceBox.width = m.voiceBox.width - 15
-    else
-        searchPoster = m.voiceBox.getChild(0)
-        if isChainValid(searchPoster, "bitmap")
-            searchPoster.bitmap = ""
-            searchPoster.blendColor = ColorPalette.WHITE
-        end if
-
-        searchText = m.voiceBox.getChild(1)
-        if isChainValid(searchText, "height")
-            searchText.vertAlign = "bottom"
-            searchText.height = 37
-        end if
-
-        m.micIcon = m.voiceBox.getChild(6)
-        if isValid(m.micIcon)
-            m.micIcon.observeFieldScoped("blendColor", "onMicIconBlendColorChange")
-        end if
-    end if
-end sub
-
-' VoiceTextEditBox.voiceEnabled doesn't have alwaysNotify enabled
-' To trigger a change event, we must change the value to something else, then back to the value we want
-sub onVoiceEnabledChange()
-    m.voiceBox.voiceEnabled = m.searchButtonDisabled
-    m.voiceBox.voiceEnabled = not m.searchButtonDisabled
-end sub
-
-sub onMicIconBlendColorChange()
-    ' DARKGREY: 269488383
-    ' WHITE: -1
-    ' LIGHTGREY: -1431655681
-    ' HIGHLIGHT: -9934849
-
-    if m.voiceBoxBackground.blendColor = -9934849
-        if m.micIcon.blendColor <> -1
-            m.micIcon.blendColor = ColorPalette.WHITE
-        end if
-    else
-        if m.micIcon.blendColor <> 269488383
-            m.micIcon.blendColor = ColorPalette.DARKGREY
-        end if
-    end if
 end sub
 
 sub OnScreenHidden()
@@ -268,6 +282,8 @@ sub loadInitialItems()
     m.loadItemsTask.control = TaskControl.STOP
     startLoadingSpinner(false)
 
+    m.dropdownOptionGroup.parentItemID = m.top.parentItem.Id
+
     if isValid(m.top.parentItem.backdropUrl)
         SetBackground(m.top.parentItem.backdropUrl)
     else
@@ -311,6 +327,8 @@ sub loadInitialItems()
     if not isValidAndNotEmpty(m.view) then m.view = "presentation"
     if not isValid(m.sortAscending) then m.sortAscending = true
     if not isStringEqual(type(m.sortAscending), "roBoolean") then m.sortAscending = true
+
+    m.dropdownOptionGroup@.setSortAscending(m.sortAscending)
 
     ' If view is not valid, use default view
     if not inArray(["presentation", "grid", "Genres", "Episodes"], m.view) then m.view = "presentation"
@@ -376,7 +394,7 @@ sub loadInitialItems()
                 end if
             else
                 if isValid(m.top.parentItem.parentFolder)
-                    disableSearch(tr("Search is unavailable because the API does not support searching inside boxsets."))
+                    m.dropdownOptionGroup@.disableSearch(tr("Search is unavailable because the API does not support searching inside boxsets."))
                 end if
             end if
         end if
@@ -497,7 +515,7 @@ sub loadInitialItems()
     end if
 
     if isStringEqual(m.top.mediaType, ItemType.MYLIST)
-        disableSearch(tr("Search is unavailable because the API does not support searching inside My List."))
+        m.dropdownOptionGroup@.disableSearch(tr("Search is unavailable because the API does not support searching inside My List."))
 
         m.itemGrid.itemComponentName = "GridItemMedium"
         m.itemGrid.itemSize = "[400, 330]"
@@ -893,6 +911,7 @@ sub setSelectedOptions(options)
     end for
 
     m.options.options = options
+    m.dropdownOptionGroup@.setOptionData(options)
     m.dropdownOptionGroup@.setText("sortOrderButton", m.sortAscending ? tr("Ascending") : tr("Descending"))
 end sub
 
@@ -986,8 +1005,8 @@ sub ItemDataLoaded(msg)
         if m.loadedItems = 0
             m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
             m.emptyText.visible = true
-            m.voiceBox.setfocus(true)
-            setSearchBackground(SearchButtonState.ACTIVE)
+            m.dropdownOptionGroup@.setFocus("voiceBox")
+            m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
             group = m.global.sceneManager.callFunc("getActiveScene")
             group.lastFocus = m.voiceBox
         end if
@@ -1048,8 +1067,8 @@ sub ItemDataLoaded(msg)
 
         m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
         m.emptyText.visible = true
-        m.voiceBox.setfocus(true)
-        setSearchBackground(SearchButtonState.ACTIVE)
+        m.dropdownOptionGroup@.setFocus("voiceBox")
+        m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
         group = m.global.sceneManager.callFunc("getActiveScene")
         group.lastFocus = m.voiceBox
     end if
@@ -1386,9 +1405,9 @@ sub processDropdownState(searchTerm as string)
 end sub
 
 sub setDropdownDisabledState(disabledState = false as boolean)
-    m.sortButton.disabled = disabledState
-    m.sortOrderButton.disabled = disabledState
-    m.filterButton.disabled = disabledState
+    m.dropdownOptionGroup@.setDisabled("sortButton", disabledState)
+    m.dropdownOptionGroup@.setDisabled("sortOrderButton", disabledState)
+    m.dropdownOptionGroup@.setDisabled("filterButton", disabledState)
 end sub
 
 sub resetDropdownsToDefaultState()
@@ -1402,6 +1421,7 @@ sub resetDropdownsToDefaultState()
         m.sortField = "SortName"
     end if
     m.sortAscending = true
+    m.dropdownOptionGroup@.setSortAscending(true)
 
     ' Reset view to defaults
     set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
@@ -1417,15 +1437,45 @@ sub resetDropdownsToDefaultState()
 end sub
 
 sub onSearchTermChanged()
-    m.voiceBox.hintText = m.top.searchTerm = string.EMPTY ? tr("Press OK to type") : m.top.searchTerm
+    searchTerm = m.top.searchTerm.trim()
 
-    onVoiceEnabledChange()
+    if not isValidAndNotEmpty(searchTerm) then return
+
+    ' If user searched for a letter, selected it from the alpha menu
+    if searchTerm.len() = 1
+        alphaMenu = m.top.findNode("alphaMenu")
+        intConversion = searchTerm.ToInt() ' non numeric input returns as 0
+
+        if searchTerm = "0" or (isValid(intConversion) and intConversion <> 0)
+            alphaMenu.jumpToItem = 0
+        else
+            ' loop through each option until we find a match
+            for i = 1 to alphaMenu.numRows - 1
+                alphaMenuOption = alphaMenu.content.getChild(i)
+                if isStringEqual(alphaMenuOption.TITLE, searchTerm)
+                    alphaMenu.jumpToItem = i
+                    exit for
+                end if
+            end for
+        end if
+
+        m.dropdownOptionGroup@.setSearchHintText(string.EMPTY)
+        m.top.alphaSelected = searchTerm
+        return
+    end if
+
+    if m.searchButtonDisabled
+        m.itemGrid.setFocus(m.itemGrid.opacity = 1)
+        m.genreList.setFocus(m.genreList.opacity = 1)
+        return
+    end if
 
     if isStringEqual(m.loadItemsTask.searchTerm, m.top.searchTerm) then return
 
-    setSearchBackground(SearchButtonState.INACTIVE)
+    m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.INACTIVE)
 
     processDropdownState(m.top.searchTerm)
+    m.dropdownOptionGroup@.setSearchHintText(m.top.searchTerm)
 
     if m.bypassSearchEvent
         m.bypassSearchEvent = false
@@ -1446,7 +1496,7 @@ end sub
 
 sub alphaSelectedChanged()
     ' Prevent voicebox change double firing
-    if m.voiceBox.text = string.EMPTY
+    if isStringEqual(m.top.searchTerm, string.EMPTY)
         ' Allow user to toggle by clicking letter twice
         if isStringEqual(m.loadItemsTask.nameStartsWith, m.top.alphaSelected)
             m.top.alphaSelected = string.EMPTY
@@ -1464,50 +1514,9 @@ sub alphaSelectedChanged()
     m.genreList.content = m.genreData
 
     m.loadItemsTask.nameStartsWith = m.top.alphaSelected
-    m.voiceBox.text = string.EMPTY
+    m.dropdownOptionGroup@.setText("voiceBox", string.EMPTY)
     m.top.searchTerm = string.EMPTY
     loadInitialItems()
-end sub
-
-sub onvoiceFilter()
-    if not isValidAndNotEmpty(m.voiceBox.text) then return
-
-    m.dropdownOptionGroup@.unfocusAllButtons()
-
-    if isStringEqual(m.voiceBox.text.trim(), "reset search") then m.voiceBox.text = string.EMPTY
-    if isStringEqual(m.voiceBox.text.trim(), "clear search") then m.voiceBox.text = string.EMPTY
-
-    m.voiceBox.hintText = m.voiceBox.text
-
-    ' If user searched for a letter, selected it from the alpha menu
-    if m.voiceBox.text.len() = 1
-        alphaMenu = m.top.findNode("alphaMenu")
-        intConversion = m.voiceBox.text.ToInt() ' non numeric input returns as 0
-
-        if m.voiceBox.text = "0" or (isValid(intConversion) and intConversion <> 0)
-            alphaMenu.jumpToItem = 0
-        else
-            ' loop through each option until we find a match
-            for i = 1 to alphaMenu.numRows - 1
-                alphaMenuOption = alphaMenu.content.getChild(i)
-                if isStringEqual(alphaMenuOption.TITLE, m.voiceBox.text)
-                    alphaMenu.jumpToItem = i
-                    exit for
-                end if
-            end for
-        end if
-
-        m.top.alphaSelected = m.voiceBox.text
-        return
-    end if
-
-    if m.searchButtonDisabled
-        m.itemGrid.setFocus(m.itemGrid.opacity = 1)
-        m.genreList.setFocus(m.genreList.opacity = 1)
-        return
-    end if
-
-    m.top.searchTerm = m.voiceBox.text.trim()
 end sub
 
 '
@@ -1520,8 +1529,7 @@ sub onOptionsVisibleChange()
     ' Nothing changed
     if isStringEqual(m.options.filter, m.filter)
         if AssocArrayEqual(m.options.filterOptions, m.filterOptions)
-            m.filterButton.focus = true
-            m.filterButton.setfocus(true)
+            m.dropdownOptionGroup@.setFocus("filterButton", true)
             return
         end if
     end if
@@ -1550,7 +1558,7 @@ sub onOptionsVisibleChange()
         loadInitialItems()
     end if
 
-    m.filterButton.focus = false
+    m.dropdownOptionGroup@.setFocus("filterButton", false)
 
     m.itemGrid.setFocus(m.itemGrid.opacity = 1)
     m.genreList.setFocus(m.genreList.opacity = 1)
@@ -1559,19 +1567,18 @@ sub onOptionsVisibleChange()
     group.lastFocus = m.itemGrid.opacity = 1 ? m.itemGrid : m.genreList
 end sub
 
-sub onSortChange()
-    m.global.sceneManager.unobserveFieldScoped("returnData")
-    sortChoice = m.global.sceneManager.returnData
-
+sub onSortChange(sortChoice)
     if not isChainValid(sortChoice, "name") then return
     if isStringEqual(sortChoice.LookupCI("name"), m.sortField) then return
 
-    m.sortButton.focus = false
+    m.dropdownOptionGroup@.setFocus("sortButton", false)
+
     m.itemGrid.setFocus(m.itemGrid.opacity = 1)
     m.genreList.setFocus(m.genreList.opacity = 1)
 
     m.sortField = sortChoice.LookupCI("name")
     m.dropdownOptionGroup@.setText("sortButton", tr(sortChoice.LookupCI("title")))
+    m.dropdownOptionGroup@.setSortAscending(true)
     m.sortAscending = true
 
     set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
@@ -1583,13 +1590,11 @@ sub onSortChange()
     loadInitialItems()
 end sub
 
-sub onViewChange()
-    m.global.sceneManager.unobserveFieldScoped("returnData")
-    viewChoice = m.global.sceneManager.returnData
+sub onViewChange(viewChoice)
     if not isChainValid(viewChoice, "name") then return
     if isStringEqual(viewChoice.LookupCI("name"), m.view) then return
 
-    m.viewButton.focus = false
+    m.dropdownOptionGroup@.setFocus("viewButton", false)
 
     ' If we're moving to or from the episodes view, we must recreate the item grid to change the itemComponentName property
     if inArray([m.view, viewChoice.LookupCI("name")], "Episodes")
@@ -1620,6 +1625,7 @@ sub onViewChange()
         m.sortField = "SortName"
     end if
     m.sortAscending = true
+    m.dropdownOptionGroup@.setSortAscending(true)
 
     ' Reset view to defaults
     set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
@@ -1664,17 +1670,16 @@ sub createItemGrid(itemGridID = "itemGrid" as string)
     m.itemGridMove.fieldToInterp = `${m.itemGrid.id}.translation`
 end sub
 
-sub onSortOrderChange()
-    m.global.sceneManager.unobserveFieldScoped("returnData")
-    sortOrderChoice = m.global.sceneManager.returnData
+sub onSortOrderChange(sortOrderChoice)
     if not isChainValid(sortOrderChoice, "name") then return
     if m.sortAscending = isStringEqual(sortOrderChoice.LookupCI("name"), "ascending") then return
 
-    m.sortOrderButton.focus = false
+    m.dropdownOptionGroup@.setFocus("sortOrderButton", false)
     m.itemGrid.setFocus(m.itemGrid.opacity = 1)
     m.genreList.setFocus(m.genreList.opacity = 1)
 
     m.sortAscending = isStringEqual(sortOrderChoice.LookupCI("name"), "Ascending")
+    m.dropdownOptionGroup@.setSortAscending(m.sortAscending)
     m.dropdownOptionGroup@.setText("sortOrderButton", tr(sortOrderChoice.LookupCI("title")))
 
     set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", m.sortAscending.toStr())
@@ -1685,35 +1690,6 @@ sub onSortOrderChange()
     m.itemGrid.content = m.data
     loadInitialItems()
 end sub
-
-' Using the user's cursor position, determine which dropdown is above them
-function getOverhangingButton()
-    if m.itemGrid.isinFocusChain()
-        if m.itemGrid.numColumns = 4
-            shortButtonList = [m.voiceBox, m.sortButton, m.filterButton, m.viewButton]
-            return shortButtonList[m.itemGrid.currFocusColumn]
-        end if
-
-        buttonList = [m.voiceBox, m.sortButton, m.sortOrderButton, m.filterButton, m.viewButton]
-
-        columnDisplacement = (m.itemGrid.numColumns / buttonList.count())
-
-        calculatedButtonIndex = CInt(((m.itemGrid.currFocusColumn + 1) / columnDisplacement) - 1)
-        if calculatedButtonIndex < 0 then calculatedButtonIndex = 0
-        if calculatedButtonIndex >= buttonList.count() then calculatedButtonIndex = buttonList.count() - 1
-        return buttonList[calculatedButtonIndex]
-    end if
-
-    if m.genreList.isinFocusChain()
-        if m.genreList.currFocusColumn <= 0 then return m.voiceBox
-        if m.genreList.currFocusColumn <= 2 then return m.sortButton
-        if m.genreList.currFocusColumn <= 3 then return m.sortOrderButton
-        if m.genreList.currFocusColumn <= 5 then return m.filterButton
-        return m.viewButton
-    end if
-
-    return m.voiceBox
-end function
 
 sub onLibrarySettingsSelected()
     m.global.sceneManager.callFunc("librarySettingDialog", tr("Library Settings"))
@@ -1768,70 +1744,18 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 toggleDropdownOptions(true)
             end if
 
-            overhangButton = getOverhangingButton()
+            overhangButton = m.dropdownOptionGroup@.getOverhangingButton(m.itemGrid.numColumns, m.itemGrid.currFocusColumn)
+
             if overhangButton.isSubType("VoiceTextEditBox")
-                setSearchBackground(SearchButtonState.ACTIVE)
+                m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
             else
-                overhangButton.focus = true
+                m.dropdownOptionGroup@.setFocus(overhangButton.id, true)
             end if
             overhangButton.setFocus(true)
             group = m.global.sceneManager.callFunc("getActiveScene")
             group.lastFocus = overhangButton
             return true
         end if
-    end if
-
-    if m.dropdownOptionGroup.isinFocusChain()
-        if isStringEqual(key, KeyCode.LEFT)
-            alphaDisplayed = m.alpha.callFunc("getDisplay")
-
-            if m.voiceBox.isinFocusChain()
-                setSearchBackground(SearchButtonState.INACTIVE)
-                m.sortButton.focus = false
-                m.sortOrderButton.focus = false
-                m.viewButton.focus = false
-                m.filterButton.focus = false
-
-                if alphaDisplayed
-                    m.top.alphaActive = true
-                    m.alphaMenu.setFocus(true)
-                    group = m.global.sceneManager.callFunc("getActiveScene")
-                    group.lastFocus = m.alphaMenu
-                else
-                    m.librarySettings.setFocus(true)
-                    m.librarySettings.highlighted = true
-                    group = m.global.sceneManager.callFunc("getActiveScene")
-                    group.lastFocus = m.librarySettings
-                end if
-                return true
-            end if
-        end if
-
-        if isStringEqual(key, KeyCode.DOWN)
-            if m.loadedItems = 0 then return false
-
-            setSearchBackground(SearchButtonState.INACTIVE)
-            m.sortButton.focus = false
-            m.sortOrderButton.focus = false
-            m.viewButton.focus = false
-            m.filterButton.focus = false
-
-            m.itemGrid.setFocus(m.itemGrid.opacity = 1)
-            m.genreList.setFocus(m.genreList.opacity = 1)
-
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = m.itemGrid
-            return true
-        end if
-    end if
-
-    if isStringEqual(key, KeyCode.LEFT) and m.voiceBox.isinFocusChain()
-        m.itemGrid.setFocus(m.itemGrid.opacity = 1)
-        m.genreList.setFocus(m.genreList.opacity = 1)
-        m.voiceBox.setFocus(false)
-        setSearchBackground(SearchButtonState.INACTIVE)
-        group = m.global.sceneManager.callFunc("getActiveScene")
-        group.lastFocus = m.itemGrid.opacity = 1 ? m.itemGrid : m.genreList
     end if
 
     if isStringEqual(key, KeyCode.BACK)
@@ -1905,7 +1829,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.alphaMenu.setFocus(false)
 
             if m.loadedItems = 0
-                m.sortButton.focus = true
+                m.dropdownOptionGroup@.setFocus("sortButton", true)
                 m.sortButton.setfocus(true)
                 group = m.global.sceneManager.callFunc("getActiveScene")
                 group.lastFocus = m.sortButton
@@ -1988,39 +1912,4 @@ sub reclaimResources()
 
     m.genreData = CreateObject("roSGNode", "ContentNode")
     m.genreList.content = m.genreData
-end sub
-
-sub setSearchBackground(state)
-    if state = SearchButtonState.ACTIVE
-        if m.searchButtonDisabled
-            m.voiceBox.textColor = ColorPalette.MIDGREY
-            m.voiceBox.hintTextColor = ColorPalette.MIDGREY
-            m.voiceBoxBackground.blendColor = ColorPalette.DARKGREY
-            return
-        end if
-
-        m.voiceBox.textColor = ColorPalette.WHITE
-        m.voiceBox.hintTextColor = ColorPalette.WHITE
-        m.voiceBoxBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-        return
-    end if
-
-    if state = SearchButtonState.DISABLED
-        m.voiceBox.textColor = ColorPalette.DARKGREY
-        m.voiceBox.hintTextColor = ColorPalette.DARKGREY
-        m.voiceBoxBackground.blendColor = ColorPalette.MIDGREY
-        return
-    end if
-
-    m.voiceBox.textColor = ColorPalette.MIDGREY
-    m.voiceBox.hintTextColor = ColorPalette.MIDGREY
-    m.voiceBoxBackground.blendColor = ColorPalette.WHITE
-end sub
-
-sub disableSearch(disabledReason as string)
-    m.disabledReason = disabledReason
-    m.searchButtonDisabled = true
-    m.voiceBox.voiceEnabled = false
-    m.voiceBox.hintText = "Search Unavailable"
-    setSearchBackground(SearchButtonState.DISABLED)
 end sub

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -850,14 +850,6 @@ function getCollectionType() as string
     return m.top.parentItem.collectionType ?? m.top.parentItem.Type
 end function
 
-' Search string array for search value. Return if it's found
-function inStringArray(array, searchValue) as boolean
-    for each item in array
-        if lcase(item) = lcase(searchValue) then return true
-    end for
-    return false
-end function
-
 ' Data to display when options button selected
 sub setSelectedOptions(options)
 
@@ -1415,9 +1407,12 @@ sub resetDropdownsToDefaultState()
     m.filterOptions = {}
     if isStringEqual(getCollectionType(), ItemType.BOXSET)
         m.sortField = "PremiereDate,SortName"
+        m.dropdownOptionGroup@.setText("sortButton", tr("Release Date"))
     else if isStringEqual(getCollectionType(), ItemType.MYLIST)
         m.sortField = "OrderAdded"
+        m.dropdownOptionGroup@.setText("sortButton", tr("Date Added"))
     else
+        m.dropdownOptionGroup@.setText("sortButton", tr("Name"))
         m.sortField = "SortName"
     end if
     m.sortAscending = true
@@ -1432,6 +1427,9 @@ sub resetDropdownsToDefaultState()
     if not isStringEqual(m.view, "Genres")
         set_user_setting(`display.${m.top.mediaType}library.defaultview`, m.view)
     end if
+
+    m.dropdownOptionGroup@.setText("sortOrderButton", tr("Ascending"))
+    m.dropdownOptionGroup@.setText("filterButton", tr("All"))
 
     m.getFiltersTask.control = "RUN"
 end sub

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -25,8 +25,6 @@ sub setupNodes()
     m.top.imageDisplayMode = "scaleToZoom"
     m.top.showItemTitles = "showonhover"
 
-    m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
-
     m.librarySettings = m.top.findNode("librarySettings")
     m.librarySettings.observeFieldScoped("selected", "onLibrarySettingsSelected")
     m.librarySettings.highlightBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
@@ -70,6 +68,8 @@ sub onShowOptionsChange()
 end sub
 
 sub onExit()
+    m.global.sceneManager.unobserveFieldScoped("returnData")
+
     dropdownExitDirection = m.dropdownOptionGroup.exit
 
     if dropdownExitDirection = ExitDirection.LEFT
@@ -102,6 +102,8 @@ sub onExit()
 end sub
 
 sub onReturnData()
+    m.global.sceneManager.unobserveFieldScoped("returnData")
+
     selectedOptionData = m.global.sceneManager.returnData
     if not isValidAndNotEmpty(selectedOptionData) then return
 
@@ -998,6 +1000,7 @@ sub ItemDataLoaded(msg)
         if m.loadedItems = 0
             m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
             m.emptyText.visible = true
+            m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
             m.dropdownOptionGroup@.setFocus("voiceBox", true)
             m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
         end if
@@ -1058,7 +1061,8 @@ sub ItemDataLoaded(msg)
 
         m.emptyText.text = tr("No items found. Try adjusting your selected filters.")
         m.emptyText.visible = true
-        m.dropdownOptionGroup@.setFocus("voiceBox")
+        m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
+        m.dropdownOptionGroup@.setFocus("voiceBox", true)
         m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
     end if
 
@@ -1529,6 +1533,8 @@ sub onOptionsVisibleChange()
         end if
     end if
 
+    m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
+
     if m.options.filter <> m.filter
         m.filter = m.options.filter
         reload = true
@@ -1740,6 +1746,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
 
             overhangButton = m.dropdownOptionGroup@.getOverhangingButton(m.itemGrid.numColumns, m.itemGrid.currFocusColumn)
+            m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
 
             if overhangButton.isSubType("VoiceTextEditBox")
                 m.dropdownOptionGroup@.setSearchBackground(SearchButtonState.ACTIVE)
@@ -1824,6 +1831,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
             m.alphaMenu.setFocus(false)
 
             if m.loadedItems = 0
+                m.global.sceneManager.observeFieldScoped("returnData", "onReturnData")
                 m.dropdownOptionGroup@.setFocus("sortButton", true)
                 m.sortButton.setfocus(true)
                 group = m.global.sceneManager.callFunc("getActiveScene")
@@ -1907,4 +1915,6 @@ sub reclaimResources()
 
     m.genreData = CreateObject("roSGNode", "ContentNode")
     m.genreList.content = m.genreData
+
+    m.global.sceneManager.unobserveFieldScoped("returnData")
 end sub

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1408,14 +1408,20 @@ sub resetDropdownsToDefaultState()
     m.filterOptions = {}
     if isStringEqual(getCollectionType(), ItemType.BOXSET)
         m.sortField = "PremiereDate,SortName"
-        m.dropdownOptionGroup@.setText("sortButton", tr("Release Date"))
     else if isStringEqual(getCollectionType(), ItemType.MYLIST)
         m.sortField = "OrderAdded"
-        m.dropdownOptionGroup@.setText("sortButton", tr("Date Added"))
     else
-        m.dropdownOptionGroup@.setText("sortButton", tr("Name"))
         m.sortField = "SortName"
     end if
+
+    ' Set selected sort option
+    for each o in m.options.options.sort
+        if o.Name = m.sortField
+            m.dropdownOptionGroup@.setText("sortButton", tr(o.LookupCI("title")))
+            o.Selected = true
+        end if
+    end for
+
     m.sortAscending = true
     m.dropdownOptionGroup@.setSortAscending(true)
 

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -56,33 +56,6 @@ sub setupNodes()
     m.star = m.top.findNode("star")
     m.dropdownOptions = m.top.findNode("dropdownOptions")
     m.dropdownOptionGroup = m.top.findNode("dropdownOptionGroup")
-    m.submitButton = m.top.findNode("submitButton")
-
-    m.sortButton = m.top.findNode("sortButton")
-    m.sortButton.textColor = ColorPalette.DARKGREY
-    m.sortButton.focusTextColor = ColorPalette.WHITE
-    m.sortButton.background = ColorPalette.WHITE
-    m.sortButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-
-    m.sortOrderButton = m.top.findNode("sortOrderButton")
-    m.sortOrderButton.textColor = ColorPalette.DARKGREY
-    m.sortOrderButton.focusTextColor = ColorPalette.WHITE
-    m.sortOrderButton.background = ColorPalette.WHITE
-    m.sortOrderButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-
-    m.filterButton = m.top.findNode("filterButton")
-    m.filterButton.textColor = ColorPalette.DARKGREY
-    m.filterButton.focusTextColor = ColorPalette.WHITE
-    m.filterButton.background = ColorPalette.WHITE
-    m.filterButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-
-    m.viewButton = m.top.findNode("viewButton")
-    m.viewButton.textColor = ColorPalette.DARKGREY
-    m.viewButton.focusTextColor = ColorPalette.WHITE
-    m.viewButton.background = ColorPalette.WHITE
-    m.viewButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
-
-    setSearchBackground(SearchButtonState.INACTIVE)
 end sub
 
 sub init()
@@ -873,7 +846,7 @@ sub setSelectedOptions(options)
     ' Set selected view option
     for each o in options.views
         if o.Name = m.view
-            m.viewButton.text = tr(o.LookupCI("title"))
+            m.dropdownOptionGroup@.setText("viewButton", tr(o.LookupCI("title")))
             o.Selected = true
         end if
     end for
@@ -881,7 +854,7 @@ sub setSelectedOptions(options)
     ' Set selected sort option
     for each o in options.sort
         if o.Name = m.sortField
-            m.sortButton.text = tr(o.LookupCI("title"))
+            m.dropdownOptionGroup@.setText("sortButton", tr(o.LookupCI("title")))
             o.Selected = true
         end if
     end for
@@ -890,7 +863,7 @@ sub setSelectedOptions(options)
     for each o in options.filter
         if o.Name = m.filter
             o.Selected = true
-            m.filterButton.text = tr(o.LookupCI("title"))
+            m.dropdownOptionGroup@.setText("filterButton", tr(o.LookupCI("title")))
             m.options.filter = o.Name
         end if
 
@@ -920,7 +893,7 @@ sub setSelectedOptions(options)
     end for
 
     m.options.options = options
-    m.sortOrderButton.text = m.sortAscending ? tr("Ascending") : tr("Descending")
+    m.dropdownOptionGroup@.setText("sortOrderButton", m.sortAscending ? tr("Ascending") : tr("Descending"))
 end sub
 
 '
@@ -1158,7 +1131,7 @@ end sub
 sub onItemFocused()
     focusedRow = m.itemGrid.currFocusRow
 
-    if m.itemGrid.isinFocusChain() or m.dropdownOptions.isinFocusChain()
+    if m.itemGrid.isinFocusChain() or m.dropdownOptionsGroup.isinFocusChain()
         if focusedRow = 0
             if m.dropdownOptionGroup.opacity < 1
                 toggleDropdownOptions(true)
@@ -1496,18 +1469,10 @@ sub alphaSelectedChanged()
     loadInitialItems()
 end sub
 
-sub unfocusAllButtons()
-    setSearchBackground(SearchButtonState.INACTIVE)
-    m.sortButton.focus = false
-    m.sortOrderButton.focus = false
-    m.filterButton.focus = false
-    m.viewButton.focus = false
-end sub
-
 sub onvoiceFilter()
     if not isValidAndNotEmpty(m.voiceBox.text) then return
 
-    unfocusAllButtons()
+    m.dropdownOptionGroup@.unfocusAllButtons()
 
     if isStringEqual(m.voiceBox.text.trim(), "reset search") then m.voiceBox.text = string.EMPTY
     if isStringEqual(m.voiceBox.text.trim(), "clear search") then m.voiceBox.text = string.EMPTY
@@ -1606,8 +1571,7 @@ sub onSortChange()
     m.genreList.setFocus(m.genreList.opacity = 1)
 
     m.sortField = sortChoice.LookupCI("name")
-    m.sortButton.text = tr(sortChoice.LookupCI("title"))
-
+    m.dropdownOptionGroup@.setText("sortButton", tr(sortChoice.LookupCI("title")))
     m.sortAscending = true
 
     set_user_setting("display." + m.top.parentItem.Id + ".sortField", m.sortField)
@@ -1636,7 +1600,7 @@ sub onViewChange()
     end if
 
     m.view = viewChoice.LookupCI("name")
-    m.viewButton.text = tr(viewChoice.LookupCI("title"))
+    m.dropdownOptionGroup@.setText("viewButton", tr(viewChoice.LookupCI("title")))
 
     set_user_setting("display." + m.top.parentItem.Id + ".landing", m.view)
 
@@ -1711,7 +1675,7 @@ sub onSortOrderChange()
     m.genreList.setFocus(m.genreList.opacity = 1)
 
     m.sortAscending = isStringEqual(sortOrderChoice.LookupCI("name"), "Ascending")
-    m.sortOrderButton.text = tr(sortOrderChoice.LookupCI("title"))
+    m.dropdownOptionGroup@.setText("sortOrderButton", tr(sortOrderChoice.LookupCI("title")))
 
     set_user_setting("display." + m.top.parentItem.Id + ".sortAscending", m.sortAscending.toStr())
 
@@ -1817,76 +1781,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         end if
     end if
 
-    if isStringEqual(key, KeyCode.OK)
-        if m.voiceBox.isinFocusChain()
-            if m.searchButtonDisabled
-                m.global.sceneManager.callFunc("standardDialog", "Search Unavailable", { data: [`<p>${m.disabledReason}</p>`] })
-                return false
-            end if
-
-            buttonData = [
-                tr("Search")
-            ]
-
-            m.global.sceneManager.callFunc("keyboardDialog", "searchLibrary", tr("Search this library"), [""], buttonData, m.top.searchTerm, m.top.parentItem.Id)
-            return true
-        end if
-
-        if m.sortButton.isinFocusChain()
-            if m.sortButton.disabled then return false
-
-            sortData = {
-                data: m.options.options.sort
-            }
-
-            m.global.sceneManager.callFunc("radioDialog", tr("Sort By"), sortData)
-            m.global.sceneManager.observeFieldScoped("returnData", "onSortChange")
-            return true
-        end if
-
-        if m.sortOrderButton.isinFocusChain()
-            if m.sortOrderButton.disabled then return false
-
-            sortOrderData = {
-                data: [
-                    { Title: tr("Ascending"), Name: "ascending", Track: { description: tr("Ascending") } },
-                    { Title: tr("Descending"), Name: "descending", Track: { description: tr("Descending") } },
-                ]
-            }
-
-            if m.sortAscending
-                sortOrderData.data[0].selected = true
-            else
-                sortOrderData.data[1].selected = true
-            end if
-
-            m.global.sceneManager.callFunc("radioDialog", tr("Sort Order"), sortOrderData)
-            m.global.sceneManager.observeFieldScoped("returnData", "onSortOrderChange")
-            return true
-        end if
-
-        if m.filterButton.isinFocusChain()
-            if m.filterButton.disabled then return false
-
-            m.options.visible = true
-            m.options.findNode("filterMenu").setFocus(true)
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = m.options
-            return true
-        end if
-
-        if m.viewButton.isinFocusChain()
-            viewData = {
-                data: m.options.options.views
-            }
-
-            m.global.sceneManager.callFunc("radioDialog", tr("TAB_VIEW"), viewData)
-            m.global.sceneManager.observeFieldScoped("returnData", "onViewChange")
-            return true
-        end if
-    end if
-
-    if m.dropdownOptions.isinFocusChain()
+    if m.dropdownOptionGroup.isinFocusChain()
         if isStringEqual(key, KeyCode.LEFT)
             alphaDisplayed = m.alpha.callFunc("getDisplay")
 
@@ -1908,80 +1803,6 @@ function onKeyEvent(key as string, press as boolean) as boolean
                     group = m.global.sceneManager.callFunc("getActiveScene")
                     group.lastFocus = m.librarySettings
                 end if
-                return true
-            end if
-
-            if m.sortButton.isinFocusChain()
-                m.voiceBox.setFocus(true)
-                setSearchBackground(SearchButtonState.ACTIVE)
-                m.sortButton.focus = false
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.voiceBox
-                return true
-            end if
-
-            if m.sortOrderButton.isinFocusChain()
-                m.sortButton.focus = true
-                m.sortButton.setFocus(true)
-                m.sortOrderButton.focus = false
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.sortButton
-                return true
-            end if
-
-            if m.filterButton.isinFocusChain()
-                m.filterButton.focus = false
-                m.sortOrderButton.focus = true
-                m.sortOrderButton.setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.sortOrderButton
-                return true
-            end if
-
-            if m.viewButton.isinFocusChain()
-                m.viewButton.focus = false
-                m.filterButton.focus = true
-                m.filterButton.setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.filterButton
-                return true
-            end if
-        end if
-
-        if isStringEqual(key, KeyCode.Right)
-            if m.voiceBox.isinFocusChain()
-                setSearchBackground(SearchButtonState.INACTIVE)
-                m.sortButton.focus = true
-                m.sortButton.setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.sortButton
-                return true
-            end if
-
-            if m.sortButton.isinFocusChain()
-                m.sortButton.focus = false
-                m.sortOrderButton.focus = true
-                m.sortOrderButton.setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.sortOrderButton
-                return true
-            end if
-
-            if m.sortOrderButton.isinFocusChain()
-                m.sortOrderButton.focus = false
-                m.filterButton.focus = true
-                m.filterButton.setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.filterButton
-                return true
-            end if
-
-            if m.filterButton.isinFocusChain()
-                m.filterButton.focus = false
-                m.viewButton.focus = true
-                m.viewButton.setFocus(true)
-                group = m.global.sceneManager.callFunc("getActiveScene")
-                group.lastFocus = m.viewButton
                 return true
             end if
         end if

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -55,6 +55,7 @@ sub setupNodes()
     m.infoGroup = m.top.findNode("infoGroup")
     m.star = m.top.findNode("star")
     m.dropdownOptions = m.top.findNode("dropdownOptions")
+    m.dropdownOptionGroup = m.top.findNode("dropdownOptionGroup")
     m.submitButton = m.top.findNode("submitButton")
 
     m.sortButton = m.top.findNode("sortButton")
@@ -300,7 +301,7 @@ sub loadInitialItems()
         SetBackground(string.EMPTY)
     end if
 
-    if m.dropdownOptions.opacity < 1
+    if m.dropdownOptionGroup.opacity < 1
         toggleDropdownOptions(true)
     end if
 
@@ -435,8 +436,8 @@ sub loadInitialItems()
         end if
     end if
 
-    m.dropdownOptions.translation = "[100, 540]"
-    if m.dropdownOptions.opacity < 1
+    m.dropdownOptionGroup.translation = "[100, 540]"
+    if m.dropdownOptionGroup.opacity < 1
         m.itemGrid.translation = "[100, 520]"
     else
         m.itemGrid.translation = "[100, 670]"
@@ -464,7 +465,7 @@ sub loadInitialItems()
         m.newBackdrop.opacity = 0
         m.itemLogo.visible = false
 
-        if m.dropdownOptions.opacity < 1
+        if m.dropdownOptionGroup.opacity < 1
             m.itemGrid.translation = "[100, 60]"
         else
             m.itemGrid.translation = "[100, 210]"
@@ -473,7 +474,7 @@ sub loadInitialItems()
         m.dropdownOptionsMove.keyValue = "[[100, 60], [100, 0]]"
         m.itemGridMove.keyValue = "[[100, 210], [100, 60]]"
         m.emptyText.translation = "[0, 540]"
-        m.dropdownOptions.translation = "[100, 60]"
+        m.dropdownOptionGroup.translation = "[100, 60]"
         m.itemGrid.numRows = "3"
         m.selectedItemOverview.visible = false
         m.selectedItemName.visible = false
@@ -485,7 +486,7 @@ sub loadInitialItems()
         m.newBackdrop.opacity = 0
         m.itemLogo.visible = false
 
-        if m.dropdownOptions.opacity < 1
+        if m.dropdownOptionGroup.opacity < 1
             m.itemGrid.translation = "[100, 60]"
         else
             m.itemGrid.translation = "[100, 210]"
@@ -494,7 +495,7 @@ sub loadInitialItems()
         m.dropdownOptionsMove.keyValue = "[[100, 60], [100, 0]]"
         m.itemGridMove.keyValue = "[[100, 210], [100, 60]]"
         m.emptyText.translation = "[0, 540]"
-        m.dropdownOptions.translation = "[100, 60]"
+        m.dropdownOptionGroup.translation = "[100, 60]"
         m.itemGrid.numRows = "3"
         m.selectedItemOverview.visible = false
         m.selectedItemName.visible = false
@@ -506,7 +507,7 @@ sub loadInitialItems()
         m.newBackdrop.opacity = 0
         m.itemLogo.visible = false
 
-        if m.dropdownOptions.opacity < 1
+        if m.dropdownOptionGroup.opacity < 1
             m.itemGrid.translation = "[100, 60]"
         else
             m.itemGrid.translation = "[100, 210]"
@@ -515,7 +516,7 @@ sub loadInitialItems()
         m.dropdownOptionsMove.keyValue = "[[100, 60], [100, 0]]"
         m.itemGridMove.keyValue = "[[100, 210], [100, 60]]"
         m.emptyText.translation = "[0, 540]"
-        m.dropdownOptions.translation = "[100, 60]"
+        m.dropdownOptionGroup.translation = "[100, 60]"
         m.itemGrid.numRows = "3"
         m.selectedItemOverview.visible = false
         m.selectedItemName.visible = false
@@ -1159,11 +1160,11 @@ sub onItemFocused()
 
     if m.itemGrid.isinFocusChain() or m.dropdownOptions.isinFocusChain()
         if focusedRow = 0
-            if m.dropdownOptions.opacity < 1
+            if m.dropdownOptionGroup.opacity < 1
                 toggleDropdownOptions(true)
             end if
         else if focusedRow > 0
-            if m.dropdownOptions.opacity > 0
+            if m.dropdownOptionGroup.opacity > 0
                 toggleDropdownOptions(false)
             end if
         end if
@@ -1390,11 +1391,11 @@ sub onGenreItemFocused()
 
     if m.genreList.isinFocusChain()
         if focusedRow = 0
-            if m.dropdownOptions.opacity < 1
+            if m.dropdownOptionGroup.opacity < 1
                 toggleDropdownOptions(true)
             end if
         else if focusedRow > 0
-            if m.dropdownOptions.opacity > 0
+            if m.dropdownOptionGroup.opacity > 0
                 toggleDropdownOptions(false)
             end if
         end if
@@ -1799,7 +1800,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
         if m.itemGrid.isinFocusChain() or m.genreList.isinFocusChain()
 
             ' In case user quickly moves out of grid without focused row getting updated
-            if m.dropdownOptions.opacity < 1
+            if m.dropdownOptionGroup.opacity < 1
                 toggleDropdownOptions(true)
             end if
 

--- a/components/Libraries/VisualLibraryScene.bs
+++ b/components/Libraries/VisualLibraryScene.bs
@@ -1439,7 +1439,7 @@ end sub
 sub onSearchTermChanged()
     searchTerm = m.top.searchTerm.trim()
 
-    if not isValidAndNotEmpty(searchTerm) then return
+    if not isValid(searchTerm) then return
 
     ' If user searched for a letter, selected it from the alpha menu
     if searchTerm.len() = 1

--- a/components/Libraries/VisualLibraryScene.xml
+++ b/components/Libraries/VisualLibraryScene.xml
@@ -23,80 +23,13 @@
       numColumns="1"
       rowItemSpacing="[ [20, 0] ]" />
 
-    <LayoutGroup id="dropdownOptions" layoutDirection="horiz" translation="[100, 60]" itemSpacings="[15]">
-      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
-        <Text font="font:SmallSystemFont" text="Search" />
-        <Poster id="voiceBoxBackground" uri="pkg:/images/white.9.png" blendColor="#FFFFFF" height="75" width="335">
-          <VoiceTextEditBox
-            id="voiceBox"
-            fontUri="font:SmallSystemFont"
-            maxTextLength="75"
-            height="75"
-            fontSize="28"
-            voiceEnabled="true"
-            hintText="Press OK to type"
-            visible="true"
-            width="335"
-            textColor="#777777"
-            clearOnDownKey="false" />
-        </Poster>
-      </LayoutGroup>
-      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
-        <Text id="sortLabel" font="font:SmallSystemFont" text="Sort By" />
-        <TextButton
-          id="sortButton"
-          iconSide="right"
-          fontSize="28"
-          padding="35"
-          icon="pkg:/images/icons/dropdown-dark.png"
-          focusIcon="pkg:/images/icons/dropdown-light.png"
-          text=""
-          height="75"
-          width="335" />
-      </LayoutGroup>
-      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
-        <Text id="sortOrderLabel" font="font:SmallSystemFont" text="Sort Order" />
-        <TextButton
-          id="sortOrderButton"
-          iconSide="right"
-          fontSize="28"
-          padding="35"
-          icon="pkg:/images/icons/dropdown-dark.png"
-          focusIcon="pkg:/images/icons/dropdown-light.png"
-          text=""
-          height="75"
-          width="335" />
-      </LayoutGroup>
-      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
-        <Text id="filterLabel" font="font:SmallSystemFont" text="TAB_FILTER" />
-        <TextButton
-          id="filterButton"
-          iconSide="right"
-          fontSize="28"
-          padding="35"
-          icon="pkg:/images/icons/dropdown-dark.png"
-          focusIcon="pkg:/images/icons/dropdown-light.png"
-          text=""
-          height="75"
-          width="335" />
-      </LayoutGroup>
-      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
-        <Text id="viewLabel" font="font:SmallSystemFont" text="TAB_VIEW" />
-        <TextButton
-          id="viewButton"
-          iconSide="right"
-          fontSize="28"
-          padding="35"
-          icon="pkg:/images/icons/dropdown-dark.png"
-          focusIcon="pkg:/images/icons/dropdown-light.png"
-          text=""
-          height="75"
-          width="335" />
-      </LayoutGroup>
-    </LayoutGroup>
+    <DropdownMenuRow
+      id="dropdownOptionGroup"
+      translation="[100, 60]" />
+
     <Animation id="toggleDropdownOptionsAnimation" duration="1" repeat="false" easeFunction="linear">
-      <FloatFieldInterpolator id="dropdownOptionsFade" key="[0.0, 1.0]" keyValue="[1.00, 0.00]" fieldToInterp="dropdownOptions.opacity" />
-      <Vector2DFieldInterpolator id="dropdownOptionsMove" key="[0.1, .9]" keyValue="[[100, 60], [100, 0]]" fieldToInterp="dropdownOptions.translation" />
+      <FloatFieldInterpolator id="dropdownOptionsFade" key="[0.0, 1.0]" keyValue="[1.00, 0.00]" fieldToInterp="dropdownOptionGroup.opacity" />
+      <Vector2DFieldInterpolator id="dropdownOptionsMove" key="[0.1, .9]" keyValue="[[100, 60], [100, 0]]" fieldToInterp="dropdownOptionGroup.translation" />
       <Vector2DFieldInterpolator id="itemGridMove" key="[0.1, .9]" keyValue="[[100, 210], [100, 60]]" fieldToInterp="itemGrid.translation" />
       <Vector2DFieldInterpolator id="genreListMove" key="[0.1, .9]" keyValue="[[100, 210], [100, 60]]" fieldToInterp="genrelist.translation" />
     </Animation>

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -148,6 +148,8 @@ sub setFocus(nodeID as string, value as boolean)
     end if
 end sub
 
+' _ is an unused param. It exists only because unfocusAllButtons is exposed
+' ref: https://github.com/rokucommunity/brighterscript/blob/master/docs/callfunc-operator.md#callfunc-evaluation-with-no-arguments
 sub unfocusAllButtons(_ as dynamic)
     setSearchBackground(SearchButtonState.INACTIVE)
     m.sortButton.focus = false

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/DropdownMenuID.bs"
 import "pkg:/source/enums/ExitDirection.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/SearchButtonState.bs"
@@ -328,7 +329,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 data: m.optionData.sort
             }
 
-            m.global.sceneManager.callFunc("radioDialog", tr("Sort By"), sortData)
+            m.global.sceneManager.callFunc("radioDialog", tr("Sort By"), sortData, invalid, DropdownMenuID.SORTBY)
             return true
         end if
 
@@ -348,7 +349,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 sortOrderData.data[1].selected = true
             end if
 
-            m.global.sceneManager.callFunc("radioDialog", tr("Sort Order"), sortOrderData)
+            m.global.sceneManager.callFunc("radioDialog", tr("Sort Order"), sortOrderData, invalid, DropdownMenuID.SORTORDER)
             return true
         end if
 
@@ -363,7 +364,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 data: m.optionData.views
             }
 
-            m.global.sceneManager.callFunc("radioDialog", tr("TAB_VIEW"), viewData)
+            m.global.sceneManager.callFunc("radioDialog", tr("TAB_VIEW"), viewData, invalid, DropdownMenuID.VIEW)
             return true
         end if
 

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -149,6 +149,13 @@ sub setFocus(nodeID as string, value as boolean)
     if isValid(buttonNode)
         buttonNode.focus = value
         buttonNode.setFocus(value)
+
+        if value
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            if isValid(group)
+                group.lastFocus = buttonNode
+            end if
+        end if
     end if
 end sub
 

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -366,6 +366,6 @@ sub disableSearch(disabledReason as string)
     m.disabledReason = disabledReason
     m.searchButtonDisabled = true
     m.voiceBox.voiceEnabled = false
-    setSearchHintText("Search Unavailable")
+    setSearchHintText(tr("Search Unavailable"))
     setSearchBackground(SearchButtonState.DISABLED)
 end sub

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -12,7 +12,7 @@ sub init()
 
     m.voiceBox = m.top.findNode("voiceBox")
     m.voiceBoxBackground = m.top.findNode("voiceBoxBackground")
-    m.voiceBox.observeField("text", "onvoiceFilter")
+    m.voiceBox.observeFieldScoped("text", "onvoiceFilter")
 
     if not m.global.device.hasVoiceRemote
         m.voiceBox.backgroundUri = "pkg:/images/transparent.png"

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -118,7 +118,6 @@ end sub
 
 ' Using the user's cursor position, determine which dropdown is above them
 function getOverhangingButton(numColumns as integer, currFocusColumn as integer)
-    'if m.itemGrid.isinFocusChain()
     if numColumns = 4
         shortButtonList = [m.voiceBox, m.sortButton, m.filterButton, m.viewButton]
         return shortButtonList[currFocusColumn]
@@ -132,17 +131,6 @@ function getOverhangingButton(numColumns as integer, currFocusColumn as integer)
     if calculatedButtonIndex < 0 then calculatedButtonIndex = 0
     if calculatedButtonIndex >= buttonList.count() then calculatedButtonIndex = buttonList.count() - 1
     return buttonList[calculatedButtonIndex]
-    'end if
-
-    ' if m.genreList.isinFocusChain()
-    '     if m.genreList.currFocusColumn <= 0 then return m.voiceBox
-    '     if m.genreList.currFocusColumn <= 2 then return m.sortButton
-    '     if m.genreList.currFocusColumn <= 3 then return m.sortOrderButton
-    '     if m.genreList.currFocusColumn <= 5 then return m.filterButton
-    '     return m.viewButton
-    ' end if
-
-    ' return m.voiceBox
 end function
 
 sub setFocus(nodeID as string, value as boolean)

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -1,4 +1,5 @@
 import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/ExitDirection.bs"
 import "pkg:/source/enums/KeyCode.bs"
 import "pkg:/source/enums/SearchButtonState.bs"
 import "pkg:/source/utils/config.bs"
@@ -6,9 +7,34 @@ import "pkg:/source/utils/misc.bs"
 
 sub init()
     m.searchButtonDisabled = false
+    m.sortAscending = true
 
     m.voiceBox = m.top.findNode("voiceBox")
     m.voiceBoxBackground = m.top.findNode("voiceBoxBackground")
+    m.voiceBox.observeField("text", "onvoiceFilter")
+
+    if not m.global.device.hasVoiceRemote
+        m.voiceBox.backgroundUri = "pkg:/images/transparent.png"
+        m.voiceBox.translation = "[15, 0]"
+        m.voiceBox.width = m.voiceBox.width - 15
+    else
+        searchPoster = m.voiceBox.getChild(0)
+        if isChainValid(searchPoster, "bitmap")
+            searchPoster.bitmap = ""
+            searchPoster.blendColor = ColorPalette.WHITE
+        end if
+
+        searchText = m.voiceBox.getChild(1)
+        if isChainValid(searchText, "height")
+            searchText.vertAlign = "bottom"
+            searchText.height = 37
+        end if
+
+        m.micIcon = m.voiceBox.getChild(6)
+        if isValid(m.micIcon)
+            m.micIcon.observeFieldScoped("blendColor", "onMicIconBlendColorChange")
+        end if
+    end if
 
     m.sortButton = m.top.findNode("sortButton")
     m.sortButton.textColor = ColorPalette.DARKGREY
@@ -37,10 +63,92 @@ sub init()
     setSearchBackground(SearchButtonState.INACTIVE)
 end sub
 
+sub onMicIconBlendColorChange()
+    ' DARKGREY: 269488383
+    ' WHITE: -1
+    ' LIGHTGREY: -1431655681
+    ' HIGHLIGHT: -9934849
+
+    if m.voiceBoxBackground.blendColor = -9934849
+        if m.micIcon.blendColor <> -1
+            m.micIcon.blendColor = ColorPalette.WHITE
+        end if
+    else
+        if m.micIcon.blendColor <> 269488383
+            m.micIcon.blendColor = ColorPalette.DARKGREY
+        end if
+    end if
+end sub
+
+sub setSearchHintText(value as string)
+    m.voiceBox.hintText = isStringEqual(value, string.EMPTY) ? tr("Press OK to type") : value
+end sub
+
+sub onvoiceFilter()
+    onVoiceEnabledChange()
+
+    if not isValidAndNotEmpty(m.voiceBox.text) then return
+
+    unfocusAllButtons(invalid)
+
+    searchTerm = m.voiceBox.text.trim()
+
+    if isStringEqual(searchTerm, "reset search") then searchTerm = string.EMPTY
+    if isStringEqual(searchTerm, "clear search") then searchTerm = string.EMPTY
+
+    setSearchHintText(searchTerm)
+
+    m.top.searchTerm = searchTerm
+end sub
+
 sub setText(nodeID as string, textValue as string)
     textNode = m.top.findNode(nodeID)
     if isValid(textNode)
         textNode.text = textValue
+    end if
+end sub
+
+sub setDisabled(nodeID as string, value as boolean)
+    buttonNode = m.top.findNode(nodeID)
+    if isValid(buttonNode)
+        buttonNode.disabled = value
+    end if
+end sub
+
+' Using the user's cursor position, determine which dropdown is above them
+function getOverhangingButton(numColumns as integer, currFocusColumn as integer)
+    'if m.itemGrid.isinFocusChain()
+    if numColumns = 4
+        shortButtonList = [m.voiceBox, m.sortButton, m.filterButton, m.viewButton]
+        return shortButtonList[currFocusColumn]
+    end if
+
+    buttonList = [m.voiceBox, m.sortButton, m.sortOrderButton, m.filterButton, m.viewButton]
+
+    columnDisplacement = (numColumns / buttonList.count())
+
+    calculatedButtonIndex = CInt(((currFocusColumn + 1) / columnDisplacement) - 1)
+    if calculatedButtonIndex < 0 then calculatedButtonIndex = 0
+    if calculatedButtonIndex >= buttonList.count() then calculatedButtonIndex = buttonList.count() - 1
+    return buttonList[calculatedButtonIndex]
+    'end if
+
+    ' if m.genreList.isinFocusChain()
+    '     if m.genreList.currFocusColumn <= 0 then return m.voiceBox
+    '     if m.genreList.currFocusColumn <= 2 then return m.sortButton
+    '     if m.genreList.currFocusColumn <= 3 then return m.sortOrderButton
+    '     if m.genreList.currFocusColumn <= 5 then return m.filterButton
+    '     return m.viewButton
+    ' end if
+
+    ' return m.voiceBox
+end function
+
+sub setFocus(nodeID as string, value as boolean)
+    buttonNode = m.top.findNode(nodeID)
+    if isValid(buttonNode)
+        buttonNode.focus = value
+        buttonNode.setFocus(value)
     end if
 end sub
 
@@ -79,11 +187,38 @@ sub setSearchBackground(state)
     m.voiceBoxBackground.blendColor = ColorPalette.WHITE
 end sub
 
+sub setOptionData(optionData)
+    m.optionData = optionData
+end sub
+
+sub setSortAscending(sortAscending as boolean)
+    m.sortAscending = sortAscending
+end sub
+
+' VoiceTextEditBox.voiceEnabled doesn't have alwaysNotify enabled
+' To trigger a change event, we must change the value to something else, then back to the value we want
+sub onVoiceEnabledChange()
+    m.voiceBox.voiceEnabled = m.searchButtonDisabled
+    m.voiceBox.voiceEnabled = not m.searchButtonDisabled
+end sub
+
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
     if not m.top.isinFocusChain() then return false
 
+    if isStringEqual(key, KeyCode.DOWN)
+        unfocusAllButtons(invalid)
+        m.top.exit = ExitDirection.DOWN
+        return true
+    end if
+
     if isStringEqual(key, KeyCode.LEFT)
+        if m.voiceBox.isinFocusChain()
+            unfocusAllButtons(invalid)
+            m.top.exit = ExitDirection.LEFT
+            return true
+        end if
+
         if m.sortButton.isinFocusChain()
             m.voiceBox.setFocus(true)
             setSearchBackground(SearchButtonState.ACTIVE)
@@ -174,7 +309,8 @@ function onKeyEvent(key as string, press as boolean) as boolean
                 tr("Search")
             ]
 
-            m.global.sceneManager.callFunc("keyboardDialog", "searchLibrary", tr("Search this library"), [""], buttonData, m.top.searchTerm, m.top.parentItem.Id)
+            hintText = isStringEqual(m.voiceBox.hintText.trim(), tr("Press OK to type")) ? string.EMPTY : m.voiceBox.hintText
+            m.global.sceneManager.callFunc("keyboardDialog", "searchLibrary", tr("Search this library"), [""], buttonData, hintText, m.top.parentItemID)
             return true
         end if
 
@@ -182,11 +318,10 @@ function onKeyEvent(key as string, press as boolean) as boolean
             if m.sortButton.disabled then return false
 
             sortData = {
-                data: m.options.options.sort
+                data: m.optionData.sort
             }
 
             m.global.sceneManager.callFunc("radioDialog", tr("Sort By"), sortData)
-            m.global.sceneManager.observeFieldScoped("returnData", "onSortChange")
             return true
         end if
 
@@ -207,27 +342,21 @@ function onKeyEvent(key as string, press as boolean) as boolean
             end if
 
             m.global.sceneManager.callFunc("radioDialog", tr("Sort Order"), sortOrderData)
-            m.global.sceneManager.observeFieldScoped("returnData", "onSortOrderChange")
             return true
         end if
 
         if m.filterButton.isinFocusChain()
             if m.filterButton.disabled then return false
-
-            m.options.visible = true
-            m.options.findNode("filterMenu").setFocus(true)
-            group = m.global.sceneManager.callFunc("getActiveScene")
-            group.lastFocus = m.options
+            m.top.showOptions = true
             return true
         end if
 
         if m.viewButton.isinFocusChain()
             viewData = {
-                data: m.options.options.views
+                data: m.optionData.views
             }
 
             m.global.sceneManager.callFunc("radioDialog", tr("TAB_VIEW"), viewData)
-            m.global.sceneManager.observeFieldScoped("returnData", "onViewChange")
             return true
         end if
 
@@ -236,3 +365,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
     return false
 end function
+
+sub disableSearch(disabledReason as string)
+    m.disabledReason = disabledReason
+    m.searchButtonDisabled = true
+    m.voiceBox.voiceEnabled = false
+    setSearchHintText("Search Unavailable")
+    setSearchBackground(SearchButtonState.DISABLED)
+end sub

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -1,0 +1,6 @@
+import "pkg:/source/utils/config.bs"
+import "pkg:/source/utils/misc.bs"
+
+sub init()
+
+end sub

--- a/components/Libraries/dropdowns/DropdownMenuRow.bs
+++ b/components/Libraries/dropdowns/DropdownMenuRow.bs
@@ -1,6 +1,238 @@
+import "pkg:/source/enums/ColorPalette.bs"
+import "pkg:/source/enums/KeyCode.bs"
+import "pkg:/source/enums/SearchButtonState.bs"
 import "pkg:/source/utils/config.bs"
 import "pkg:/source/utils/misc.bs"
 
 sub init()
+    m.searchButtonDisabled = false
 
+    m.voiceBox = m.top.findNode("voiceBox")
+    m.voiceBoxBackground = m.top.findNode("voiceBoxBackground")
+
+    m.sortButton = m.top.findNode("sortButton")
+    m.sortButton.textColor = ColorPalette.DARKGREY
+    m.sortButton.focusTextColor = ColorPalette.WHITE
+    m.sortButton.background = ColorPalette.WHITE
+    m.sortButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
+    m.sortOrderButton = m.top.findNode("sortOrderButton")
+    m.sortOrderButton.textColor = ColorPalette.DARKGREY
+    m.sortOrderButton.focusTextColor = ColorPalette.WHITE
+    m.sortOrderButton.background = ColorPalette.WHITE
+    m.sortOrderButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
+    m.filterButton = m.top.findNode("filterButton")
+    m.filterButton.textColor = ColorPalette.DARKGREY
+    m.filterButton.focusTextColor = ColorPalette.WHITE
+    m.filterButton.background = ColorPalette.WHITE
+    m.filterButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
+    m.viewButton = m.top.findNode("viewButton")
+    m.viewButton.textColor = ColorPalette.DARKGREY
+    m.viewButton.focusTextColor = ColorPalette.WHITE
+    m.viewButton.background = ColorPalette.WHITE
+    m.viewButton.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+
+    setSearchBackground(SearchButtonState.INACTIVE)
 end sub
+
+sub setText(nodeID as string, textValue as string)
+    textNode = m.top.findNode(nodeID)
+    if isValid(textNode)
+        textNode.text = textValue
+    end if
+end sub
+
+sub unfocusAllButtons(_ as dynamic)
+    setSearchBackground(SearchButtonState.INACTIVE)
+    m.sortButton.focus = false
+    m.sortOrderButton.focus = false
+    m.filterButton.focus = false
+    m.viewButton.focus = false
+end sub
+
+sub setSearchBackground(state)
+    if state = SearchButtonState.ACTIVE
+        if m.searchButtonDisabled
+            m.voiceBox.textColor = ColorPalette.MIDGREY
+            m.voiceBox.hintTextColor = ColorPalette.MIDGREY
+            m.voiceBoxBackground.blendColor = ColorPalette.DARKGREY
+            return
+        end if
+
+        m.voiceBox.textColor = ColorPalette.WHITE
+        m.voiceBox.hintTextColor = ColorPalette.WHITE
+        m.voiceBoxBackground.blendColor = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+        return
+    end if
+
+    if state = SearchButtonState.DISABLED
+        m.voiceBox.textColor = ColorPalette.DARKGREY
+        m.voiceBox.hintTextColor = ColorPalette.DARKGREY
+        m.voiceBoxBackground.blendColor = ColorPalette.MIDGREY
+        return
+    end if
+
+    m.voiceBox.textColor = ColorPalette.MIDGREY
+    m.voiceBox.hintTextColor = ColorPalette.MIDGREY
+    m.voiceBoxBackground.blendColor = ColorPalette.WHITE
+end sub
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+    if not m.top.isinFocusChain() then return false
+
+    if isStringEqual(key, KeyCode.LEFT)
+        if m.sortButton.isinFocusChain()
+            m.voiceBox.setFocus(true)
+            setSearchBackground(SearchButtonState.ACTIVE)
+            m.sortButton.focus = false
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.voiceBox
+            return true
+        end if
+
+        if m.sortOrderButton.isinFocusChain()
+            m.sortButton.focus = true
+            m.sortButton.setFocus(true)
+            m.sortOrderButton.focus = false
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.sortButton
+            return true
+        end if
+
+        if m.filterButton.isinFocusChain()
+            m.filterButton.focus = false
+            m.sortOrderButton.focus = true
+            m.sortOrderButton.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.sortOrderButton
+            return true
+        end if
+
+        if m.viewButton.isinFocusChain()
+            m.viewButton.focus = false
+            m.filterButton.focus = true
+            m.filterButton.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.filterButton
+            return true
+        end if
+
+        return false
+    end if
+
+    if isStringEqual(key, KeyCode.Right)
+        if m.voiceBox.isinFocusChain()
+            setSearchBackground(SearchButtonState.INACTIVE)
+            m.sortButton.focus = true
+            m.sortButton.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.sortButton
+            return true
+        end if
+
+        if m.sortButton.isinFocusChain()
+            m.sortButton.focus = false
+            m.sortOrderButton.focus = true
+            m.sortOrderButton.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.sortOrderButton
+            return true
+        end if
+
+        if m.sortOrderButton.isinFocusChain()
+            m.sortOrderButton.focus = false
+            m.filterButton.focus = true
+            m.filterButton.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.filterButton
+            return true
+        end if
+
+        if m.filterButton.isinFocusChain()
+            m.filterButton.focus = false
+            m.viewButton.focus = true
+            m.viewButton.setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.viewButton
+            return true
+        end if
+
+        return false
+    end if
+
+    if isStringEqual(key, KeyCode.OK)
+        if m.voiceBox.isinFocusChain()
+            if m.searchButtonDisabled
+                m.global.sceneManager.callFunc("standardDialog", "Search Unavailable", { data: [`<p>${m.disabledReason}</p>`] })
+                return false
+            end if
+
+            buttonData = [
+                tr("Search")
+            ]
+
+            m.global.sceneManager.callFunc("keyboardDialog", "searchLibrary", tr("Search this library"), [""], buttonData, m.top.searchTerm, m.top.parentItem.Id)
+            return true
+        end if
+
+        if m.sortButton.isinFocusChain()
+            if m.sortButton.disabled then return false
+
+            sortData = {
+                data: m.options.options.sort
+            }
+
+            m.global.sceneManager.callFunc("radioDialog", tr("Sort By"), sortData)
+            m.global.sceneManager.observeFieldScoped("returnData", "onSortChange")
+            return true
+        end if
+
+        if m.sortOrderButton.isinFocusChain()
+            if m.sortOrderButton.disabled then return false
+
+            sortOrderData = {
+                data: [
+                    { Title: tr("Ascending"), Name: "ascending", Track: { description: tr("Ascending") } },
+                    { Title: tr("Descending"), Name: "descending", Track: { description: tr("Descending") } },
+                ]
+            }
+
+            if m.sortAscending
+                sortOrderData.data[0].selected = true
+            else
+                sortOrderData.data[1].selected = true
+            end if
+
+            m.global.sceneManager.callFunc("radioDialog", tr("Sort Order"), sortOrderData)
+            m.global.sceneManager.observeFieldScoped("returnData", "onSortOrderChange")
+            return true
+        end if
+
+        if m.filterButton.isinFocusChain()
+            if m.filterButton.disabled then return false
+
+            m.options.visible = true
+            m.options.findNode("filterMenu").setFocus(true)
+            group = m.global.sceneManager.callFunc("getActiveScene")
+            group.lastFocus = m.options
+            return true
+        end if
+
+        if m.viewButton.isinFocusChain()
+            viewData = {
+                data: m.options.options.views
+            }
+
+            m.global.sceneManager.callFunc("radioDialog", tr("TAB_VIEW"), viewData)
+            m.global.sceneManager.observeFieldScoped("returnData", "onViewChange")
+            return true
+        end if
+
+        return false
+    end if
+
+    return false
+end function

--- a/components/Libraries/dropdowns/DropdownMenuRow.xml
+++ b/components/Libraries/dropdowns/DropdownMenuRow.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="DropdownMenuRow" extends="Group">
+  <children>
+    <LayoutGroup id="dropdownOptions" layoutDirection="horiz" itemSpacings="[15]">
+      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
+        <Text font="font:SmallSystemFont" text="Search" />
+        <Poster id="voiceBoxBackground" uri="pkg:/images/white.9.png" blendColor="#FFFFFF" height="75" width="335">
+          <VoiceTextEditBox
+            id="voiceBox"
+            fontUri="font:SmallSystemFont"
+            maxTextLength="75"
+            height="75"
+            fontSize="28"
+            voiceEnabled="true"
+            hintText="Press OK to type"
+            visible="true"
+            width="335"
+            textColor="#777777"
+            clearOnDownKey="false" />
+        </Poster>
+      </LayoutGroup>
+      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
+        <Text id="sortLabel" font="font:SmallSystemFont" text="Sort By" />
+        <TextButton
+          id="sortButton"
+          iconSide="right"
+          fontSize="28"
+          padding="35"
+          icon="pkg:/images/icons/dropdown-dark.png"
+          focusIcon="pkg:/images/icons/dropdown-light.png"
+          text=""
+          height="75"
+          width="335" />
+      </LayoutGroup>
+      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
+        <Text id="sortOrderLabel" font="font:SmallSystemFont" text="Sort Order" />
+        <TextButton
+          id="sortOrderButton"
+          iconSide="right"
+          fontSize="28"
+          padding="35"
+          icon="pkg:/images/icons/dropdown-dark.png"
+          focusIcon="pkg:/images/icons/dropdown-light.png"
+          text=""
+          height="75"
+          width="335" />
+      </LayoutGroup>
+      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
+        <Text id="filterLabel" font="font:SmallSystemFont" text="TAB_FILTER" />
+        <TextButton
+          id="filterButton"
+          iconSide="right"
+          fontSize="28"
+          padding="35"
+          icon="pkg:/images/icons/dropdown-dark.png"
+          focusIcon="pkg:/images/icons/dropdown-light.png"
+          text=""
+          height="75"
+          width="335" />
+      </LayoutGroup>
+      <LayoutGroup layoutDirection="vert" itemSpacings="[10]">
+        <Text id="viewLabel" font="font:SmallSystemFont" text="TAB_VIEW" />
+        <TextButton
+          id="viewButton"
+          iconSide="right"
+          fontSize="28"
+          padding="35"
+          icon="pkg:/images/icons/dropdown-dark.png"
+          focusIcon="pkg:/images/icons/dropdown-light.png"
+          text=""
+          height="75"
+          width="335" />
+      </LayoutGroup>
+    </LayoutGroup>
+  </children>
+  <interface>
+  </interface>
+</component>

--- a/components/Libraries/dropdowns/DropdownMenuRow.xml
+++ b/components/Libraries/dropdowns/DropdownMenuRow.xml
@@ -74,7 +74,19 @@
     </LayoutGroup>
   </children>
   <interface>
+    <field id="exit" type="integer" alwaysNotify="true" />
+    <field id="parentItemID" type="string" />
+    <field id="showOptions" type="boolean" alwaysNotify="true" />
+    <field id="searchTerm" type="string" alwaysNotify="true" />
     <function name="unfocusAllButtons" />
     <function name="setText" />
+    <function name="setDisabled" />
+    <function name="setFocus" />
+    <function name="setSearchHintText" />
+    <function name="setSearchBackground" />
+    <function name="getOverhangingButton" />
+    <function name="disableSearch" />
+    <function name="setOptionData" />
+    <function name="setSortAscending" />
   </interface>
 </component>

--- a/components/Libraries/dropdowns/DropdownMenuRow.xml
+++ b/components/Libraries/dropdowns/DropdownMenuRow.xml
@@ -74,5 +74,7 @@
     </LayoutGroup>
   </children>
   <interface>
+    <function name="unfocusAllButtons" />
+    <function name="setText" />
   </interface>
 </component>

--- a/components/RadioDialog.bs
+++ b/components/RadioDialog.bs
@@ -19,7 +19,7 @@ end sub
 sub onButtonSelected()
     if m.top.buttonSelected = 0
         selectedData = m.top.contentData.data[m.radioOptions.selectedIndex]
-        selectedData.id = m.top.title
+        selectedData.id = m.top.id
         m.global.sceneManager.returnData = selectedData
         return
     end if

--- a/components/RadioDialog.bs
+++ b/components/RadioDialog.bs
@@ -18,7 +18,9 @@ end sub
 ' Event handler for when user selected a button
 sub onButtonSelected()
     if m.top.buttonSelected = 0
-        m.global.sceneManager.returnData = m.top.contentData.data[m.radioOptions.selectedIndex]
+        selectedData = m.top.contentData.data[m.radioOptions.selectedIndex]
+        selectedData.id = m.top.title
+        m.global.sceneManager.returnData = selectedData
         return
     end if
 

--- a/components/data/SceneManager.bs
+++ b/components/data/SceneManager.bs
@@ -328,9 +328,13 @@ end sub
 
 '
 ' Display dialog to user with an OK button
-sub radioDialog(title, message, buttons = [tr("OK")])
+sub radioDialog(title, message, buttons = [tr("OK")], id = "OKDialog")
     m.itemID = string.EMPTY
     m.userselection = false
+
+    if not isValidAndNotEmpty(buttons)
+        buttons = [tr("OK")]
+    end if
 
     dialog = createObject("roSGNode", "RadioDialog")
     dlgPalette = createObject("roSGNode", "RSGPalette")
@@ -348,6 +352,7 @@ sub radioDialog(title, message, buttons = [tr("OK")])
     dialog.title = title
     dialog.contentData = message
     dialog.buttons = buttons
+    dialog.id = id
 
     m.scene.dialog = dialog
 end sub

--- a/locale/en_US/translations.ts
+++ b/locale/en_US/translations.ts
@@ -2403,5 +2403,9 @@
             <source>Use at your own risk. We make no guarantees this will work for you. \n 1. This feature may not work on this device, yet work on others \n 2. Some speed options may not work on this device, yet work on others \n 3. Roku may block this feature without warning; even if the Jellyfin client doesn't update</source>
             <translation>Use at your own risk. We make no guarantees this will work for you. \n 1. This feature may not work on this device, yet work on others \n 2. Some speed options may not work on this device, yet work on others \n 3. Roku may block this feature without warning; even if the Jellyfin client doesn't update</translation>
         </message>
+        <message>
+            <source>Search Unavailable</source>
+            <translation>Search Unavailable</translation>
+        </message>
     </context>
 </TS>

--- a/source/MainEventHandlers.bs
+++ b/source/MainEventHandlers.bs
@@ -1566,7 +1566,6 @@ sub onDataReturnedEvent(msg)
 
     if isStringEqual(selectedPopupID, "searchLibrary")
         searchTerm = chainLookup(popupNode, "returndata.text")
-
         if not isValid(searchTerm) then return
 
         activeScene = m.global.sceneManager.callFunc("getActiveScene")

--- a/source/enums/DropdownMenuID.bs
+++ b/source/enums/DropdownMenuID.bs
@@ -1,0 +1,5 @@
+enum DropdownMenuID
+    SORTORDER = "librarySortOrder"
+    SORTBY = "librarySortBy"
+    VIEW = "libraryView"
+end enum

--- a/source/enums/ExitDirection.bs
+++ b/source/enums/ExitDirection.bs
@@ -1,0 +1,6 @@
+enum ExitDirection
+    DOWN
+    LEFT
+    RIGHT
+    UP
+end enum


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
- Moves all dropdown filter code into its own reusable component, allowing us to reuse most of the code instead of having it duplicated in multiple files

Followup PR: Change MusicLibraryView to use new dropdown component