### PR TITLE
Fix infrequent blank trickplay image when using large trickplay tileset

### DIFF
--- a/components/video/VideoPlayerView.bs
+++ b/components/video/VideoPlayerView.bs
@@ -928,29 +928,28 @@ sub displaySingleTrickplayImage(trickPosition as integer, whichImage as integer)
 
     if offsetHoriz < 0 then offsetHoriz = 0
 
-    ' Trickplayimage node doesn't exist, create it
+    ' If we've changed tiles, remove existing trickplayImage node if it exists and we can't use fast replace.
+    ' Otherwise loading the next image will fail. 'cause Roku.
+    if isvalid(trickplayImage)
+        if trickplayImage.uri <> `tmp:/${m.top.id}-${tileIndex}.jpg` and not m.canUseFastReplace
+            m.osd.removeChild(trickplayImage)
+            trickplayImage = invalid
+        end if
+    end if
+
     if not isValid(trickplayImage)
         newTrickplayImage = createObject("roSGNode", "Poster")
-        newTrickplayImage.uri = `tmp:/${m.top.id}-${tileIndex}.jpg`
         newTrickplayImage.id = `trickplayImage` + str(whichImage)
         newTrickplayImage.loadDisplayMode = "noScale"
         newTrickplayImage.height = tileSizeFactor * m.trickplayDataFinal.Height * m.trickplayDataFinal.TileHeight
         newTrickplayImage.width = tileSizeFactor * m.trickplayDataFinal.Width * m.trickplayDataFinal.TileWidth
-        newTrickplayImage.translation = `[${offsetHoriz - (iconColumn * m.trickplayDataFinal.Width * tileSizeFactor)},  ${offsetVert - (iconRow * m.trickplayDataFinal.Height * tileSizeFactor)}]`
-        newTrickplayImage.clippingRect = `[${iconColumn * m.trickplayDataFinal.Width * tileSizeFactor}, ${iconRow * m.trickplayDataFinal.Height * tileSizeFactor}, ${m.trickplayDataFinal.Width * tileSizeFactor}, ${m.trickplayDataFinal.Height * tileSizeFactor}]`
         ' Insert trickplay image at top of OSD so video ending time node is visible over trickplay image
         m.osd.insertChild(newTrickplayImage, 0)
-        return
+        trickplayImage = newTrickplayImage
     end if
 
-    ' If we've changed tiles, remove existing trickplayImage node
-    ' Otherwise loading the next image will fail. 'cause Roku.
+    ' Only update the trickplay image's URI if needed
     if trickplayImage.uri <> `tmp:/${m.top.id}-${tileIndex}.jpg`
-        if not m.canUseFastReplace
-            m.osd.removeChild(trickplayImage)
-            return
-        end if
-
         trickplayImage.uri = `tmp:/${m.top.id}-${tileIndex}.jpg`
     end if
 
@@ -1050,7 +1049,7 @@ sub displaySegmentSkipButton(segmentType as string, endticks as double)
 
     if isStringEqual(segmentType, MediaSegmentType.OUTRO)
         if m.nextupbuttonseconds = 0 then return ' is the button disabled?
-        if not m.osd.visible 
+        if not m.osd.visible
             displayNextItem() ' only show next episode info if OSD is not visible
         end if
     end if


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.readthedocs.io/en/latest/developer-docs/contributing/ page.
-->
<!-- markdownlint-disable MD041 first-line-heading -->
## Changes
Fix an issue with a single trickplay image not showing when the tileset size is large (such as 10x10) and the tileset change.  With the example of a 10x10 tileset, for every 100 trickplay images a single blank trickplay tile will display.  This happens with both the single and five tile trickplay display, but is most visible in a screen shot with five tiles:

<img width="1920" height="1080" alt="Trickplay missing image" src="https://github.com/user-attachments/assets/92b0bee1-7302-491b-8fd6-9630f337d1f2" />

Screen shot using changed code:

<img width="1920" height="1080" alt="Trickplay image fixed" src="https://github.com/user-attachments/assets/2f164666-26d4-4f17-be21-bda8fd77cec7" />


This issue does not happen when the code identifies fast replace can be used, such as with a 5x5 tileset.  I did regression test with 5x5 and additional logging to make sure it would use fast replace.
