### PR TITLE
Add Mark As Played button to TV series details

### DIFF
--- a/components/tvshows/TVSeriesDetails.bs
+++ b/components/tvshows/TVSeriesDetails.bs
@@ -55,6 +55,11 @@ sub init()
     m.shuffle = m.top.findNode("shuffle")
     m.shuffle.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
 
+    m.markWatched = m.top.findNode("markWatched")
+    if isValid(m.markWatched)
+        m.markWatched.focusBackground = chainLookupReturn(m.global.session, "user.settings.colorCursor", ColorPalette.HIGHLIGHT)
+    end if
+
     m.previouslySelectedButtonIndex = -1
     m.top.observeField("selectedButtonIndex", "onButtonSelectedChange")
     m.top.selectedButtonIndex = 0
@@ -157,6 +162,31 @@ sub setFontSizes()
     end if
 end sub
 
+' Refresh the Mark As Played / Played button label based on series watched state
+sub updateMarkWatchedButton()
+    if not isValid(m.markWatched) then return
+    item = m.top.itemContent
+    if not isValid(item) then return
+    played = chainLookupReturn(item, "json.UserData.Played", false)
+    if played
+        m.markWatched.text = tr("Played")
+    else
+        m.markWatched.text = tr("Mark As Played")
+    end if
+end sub
+
+' Triggered when MainAction toggles itemContent.watched after the user presses
+' the Mark As Played button. Refresh the indicator and button label.
+sub onWatchedStateChange()
+    item = m.top.itemContent
+    if not isValid(item) then return
+    m.playedIndicator.data = {
+        played: chainLookupReturn(item, "json.UserData.Played", false),
+        unplayedCount: chainLookupReturn(item, "json.UserData.UnplayedItemCount", 0)
+    }
+    updateMarkWatchedButton()
+end sub
+
 sub onPosterLoadStatusChanged()
     if isStringEqual(m.tvshowPoster.loadStatus, PosterLoadStatus.FAILED)
         tryLoadingSeasonPoster()
@@ -186,6 +216,10 @@ sub itemContentChanged()
         played: chainLookupReturn(item, "json.UserData.Played", false),
         unplayedCount: chainLookupReturn(item, "json.UserData.UnplayedItemCount", 0)
     }
+
+    updateMarkWatchedButton()
+    item.unobserveFieldScoped("watched")
+    item.observeFieldScoped("watched", "onWatchedStateChange")
 
     setFieldText("title", itemData.name)
 
@@ -461,6 +495,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
 
             if m.play.hasFocus()
                 m.top.playSeriesFromStart = not m.top.playSeriesFromStart
+                return true
+            end if
+
+            if isValid(m.markWatched) and m.markWatched.hasFocus()
+                m.top.buttonSelected = "watched-button"
                 return true
             end if
 

--- a/components/tvshows/TVSeriesDetails.xml
+++ b/components/tvshows/TVSeriesDetails.xml
@@ -52,6 +52,7 @@
             <IconButton id="play" background="#070707" padding="35" icon="pkg:/images/icons/play.png" text="Play" height="65" width="140" />
             <IconButton id="shuffle" background="#070707" padding="35" icon="pkg:/images/icons/shufflePlay.png" text="Shuffle" height="65" width="140" />
             <IconButton id="extras" background="#070707" padding="15" icon="pkg:/images/icons/extras.png" text="Extras" height="65" width="140" />
+            <IconButton id="markWatched" background="#070707" padding="35" icon="pkg:/images/icons/check.png" text="Mark As Played" height="65" width="240" />
           </ButtonGroupHoriz>
         </LayoutGroup>
 
@@ -119,6 +120,7 @@
     <field id="quickPlayNode" type="node" alwaysNotify="true" />
     <field id="selectedButtonIndex" type="integer" value="-1" />
     <field id="playSeriesFromStart" type="bool" />
+    <field id="buttonSelected" type="string" alwaysNotify="true" />
     <field id="showItemTitles" type="string" value="showalways" />
   </interface>
 </component>

--- a/source/ShowScenes.bs
+++ b/source/ShowScenes.bs
@@ -826,6 +826,7 @@ function CreateSeriesDetailsGroup(seriesID as string) as dynamic
     group.observeField("seasonSelected", m.port)
     group.observeField("quickPlayNode", m.port)
     group.observeField("refreshSeasonDetailsData", m.port)
+    group.observeField("buttonSelected", m.port)
 
     ' setup and load series extras
     extras = group.findNode("extrasGrid")


### PR DESCRIPTION
## Summary
Adds a **Mark As Played / Played** button to the TV series details screen so users can toggle the watched state of an entire series in one step. Previously, the Roku client only supported per-episode toggling, even though the Jellyfin server already handles series-level `MarkPlayed`/`UnmarkPlayed` recursively.

## Motivation
A common ask: after re-watching a series the only way to reset its watched state on Roku was to walk every episode. The web UI already supports series-level toggling — this brings the Roku client to parity.

## Changes
- `components/tvshows/TVSeriesDetails.xml`
  - New `<IconButton id="markWatched">` appended to the existing button row
  - New `<field id="buttonSelected">` so the scene can dispatch button events the same way `MovieDetails` does
- `components/tvshows/TVSeriesDetails.bs`
  - Wires up `m.markWatched` in `init`
  - New `updateMarkWatchedButton()` keeps the label in sync with `UserData.Played`
  - `itemContentChanged` observes `itemContent.watched` so the indicator + label update live after a toggle
  - OK-key branch on the new button sets `m.top.buttonSelected = "watched-button"`
- `source/ShowScenes.bs`
  - The series scene now observes `buttonSelected`, matching the movie scene

The existing dispatcher in `MainEventHandlers.bs` already routes `watched-button` → `MainAction.onWatchedButtonClicked`, which works generically against any scene whose `itemContent` has `.watched` and `.id` — `SeriesData` already exposes both plus a `setWatched` interface, so no changes were needed there.

## Build
`npm run build` passes locally with no new warnings or errors on the edited files.

## Testing
- [x] `npm run build` (BrighterScript compile + lint) clean
- [ ] **Not yet tested on Roku hardware** — I don't currently have a Roku dev box set up. Happy to follow up after sideloading, but flagging upfront so a maintainer can verify on-device or guide me through any UX tweaks (button width, icon choice, focus order).

## Notes
- Scope intentionally limited to series-level. A follow-up could mirror this on `TVSeasonDetails` for season-level toggling.
- Button width set to 240 to fit "Mark As Played"; open to other copy/layout suggestions.