### PR TITLE
Fix Cinema Mode Intros APIRequest Argument Index

### DIFF
--- a/source/api/sdk.bs
+++ b/source/api/sdk.bs
@@ -426,7 +426,7 @@ namespace api
 
         ' Gets intros to play before the main media item plays.
         function GetIntros(itemid as string, params = {} as object)
-            resp = APIRequest(Substitute("/items/{1}/intros", itemid), params)
+            resp = APIRequest(Substitute("/items/{0}/intros", itemid), params)
             return getJson(resp)
         end function
 

--- a/source/static/whatsNew/3.1.10.json
+++ b/source/static/whatsNew/3.1.10.json
@@ -14,5 +14,9 @@
   {
     "description": "Use server to determine default subtitle track",
     "author": "1hitsong"
+  },
+  {
+    "description": "Fix Cinema Mode Intros",
+    "author": "Starwarsfan2099"
   }
 ]


### PR DESCRIPTION
## Changes
Tiny one byte fix in `source/api/sdk.bs` - `GetIntros` to use the correct `itemid` index. This enables the Cinema Mode and the Cinema Mode settings toggle to function again.

## Issues
This is a fix for: https://github.com/jellyfin/jellyfin-roku/issues/866
