### PR TITLE
Report playback progress every ten seconds

### DIFF
--- a/components/mediaPlayers/AudioPlayer.xml
+++ b/components/mediaPlayers/AudioPlayer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component name="AudioPlayer" extends="Video">
   <children>
-    <timer id="playbackTimer" repeat="true" duration="30" />
+    <timer id="playbackTimer" repeat="true" duration="10" />
   </children>
   <interface>
     <field id="id" type="string" />

--- a/components/video/VideoPlayerView.xml
+++ b/components/video/VideoPlayerView.xml
@@ -45,7 +45,7 @@
     </LayoutGroup>
 
     <Group id="captionGroup" translation="[0,0]" />
-    <timer id="playbackTimer" repeat="true" duration="30" />
+    <timer id="playbackTimer" repeat="true" duration="10" />
     <timer id="playbackCheckTimer" repeat="false" duration="1" />
     <timer id="bufferStuckTimer" repeat="true" duration="3" />
     <timer id="bufferCheckTimer" repeat="true" />


### PR DESCRIPTION
## Changes

Reduce the repeating playback-progress timer from 30 seconds to 10 seconds for both video and audio playback. This limits the last server-confirmed position to roughly 10 seconds behind playback when Roku exits abruptly, while increasing progress requests from about two to six per minute during playback. The server-side idle cleanup fix in jellyfin/jellyfin#17631 remains independent and correct whether or not this cadence change is accepted.

## Testing

- `npm ci`
- `npm run build`
- Confirmed both packaged staging XML files contain `duration="10"`

The build succeeds with the repository's existing BrightScript lint warnings. The generated ZIP has not been sideloaded because no Roku developer target was available, so device-specific Home-button testing is still required.

## Code assistance

OpenAI Codex assisted with codebase investigation, the focused timer edit, and local build validation. The resulting diff and build output were reviewed before submission.

## Issues

No linked issue.
